### PR TITLE
Feature: Simple Image Publisher + Minor Linefollower Module Improvement

### DIFF
--- a/followers/followers/linefollower_module.py
+++ b/followers/followers/linefollower_module.py
@@ -25,6 +25,8 @@ class LineFollowerModule:
     leftT_ = (435, 270)
     rightT_ = (5, 270)
 
+    threshold_value = 127
+
     def __init__(
             self,
             step_time: float,
@@ -151,7 +153,7 @@ class LineFollowerModule:
             processed = cv.blur(self.image_, (5, 5))
             gray = cv.cvtColor(processed, cv.COLOR_BGR2GRAY)
 
-            _, thresh = cv.threshold(gray, 127, 255, cv.THRESH_BINARY_INV)
+            _, thresh = cv.threshold(gray, self.threshold_value, 255, cv.THRESH_BINARY_INV)
             # _, thresh = cv.threshold(gray, 0, 255, cv.THRESH_BINARY_INV + cv.THRESH_OTSU)
 
             kernel = np.ones((5, 5), np.uint8)

--- a/followers/followers/linefollower_module.py
+++ b/followers/followers/linefollower_module.py
@@ -151,8 +151,8 @@ class LineFollowerModule:
             processed = cv.blur(self.image_, (5, 5))
             gray = cv.cvtColor(processed, cv.COLOR_BGR2GRAY)
 
-            # _, thresh = cv.threshold(gray, 178, 255, cv.THRESH_BINARY_INV)
-            _, thresh = cv.threshold(gray, 0, 255, cv.THRESH_BINARY_INV + cv.THRESH_OTSU)
+            _, thresh = cv.threshold(gray, 127, 255, cv.THRESH_BINARY_INV)
+            # _, thresh = cv.threshold(gray, 0, 255, cv.THRESH_BINARY_INV + cv.THRESH_OTSU)
 
             kernel = np.ones((5, 5), np.uint8)
             thresh = cv.erode(thresh, kernel, iterations=1)

--- a/followers/followers/linefollower_module.py
+++ b/followers/followers/linefollower_module.py
@@ -102,8 +102,8 @@ class LineFollowerModule:
 
     def compute_angular_velocity(self) -> Optional[float]:
         try:
-            self.__process_image()
-            contour, _ = self.__compute_max_contour()
+            self._process_image()
+            contour, _ = self._compute_max_contour()
 
         except LineFollowerModuleError as e:
             self.logger_.warning(f"Encountered error \"{e}\"."
@@ -136,8 +136,8 @@ class LineFollowerModule:
         cv.circle(self.image_debug_, self.rightT_,    radius=5, color=(0, 0, 255), thickness=-1)
 
         # recognizing 90 degree turn
-        is_left_in_polygon = self.__is_in_polygon(contour, self.leftT_)
-        is_right_in_polygon = self.__is_in_polygon(contour, self.rightT_)
+        is_left_in_polygon = self._is_in_polygon(contour, self.leftT_)
+        is_right_in_polygon = self._is_in_polygon(contour, self.rightT_)
 
         if is_left_in_polygon and not is_right_in_polygon:
             turn_offset = -self.turn_offset_#-1.0 #-1
@@ -149,10 +149,10 @@ class LineFollowerModule:
         u = np.clip(u, self.min_u_, self.max_u_)
         return u
 
-    def __is_in_polygon(self, polygon: np.ndarray, point: tuple) -> bool:
+    def _is_in_polygon(self, polygon: np.ndarray, point: tuple) -> bool:
         return cv.pointPolygonTest(polygon, point, False) >= 0
 
-    def __process_image(self) -> None:
+    def _process_image(self) -> None:
         if self.image_ is None:
             raise LineFollowerModuleError('Cannot process image when the image is not set')
 
@@ -178,7 +178,7 @@ class LineFollowerModule:
 
         raise LineFollowerModuleError('Cannot process image when input mode is not set')
 
-    def __compute_max_contour(self) -> Tuple[np.ndarray, float]:
+    def _compute_max_contour(self) -> Tuple[np.ndarray, float]:
         if self.image_binary_ is None:
             raise LineFollowerModuleError('Cannot compute max contour when the image is not set')
 

--- a/followers/followers/linefollower_module.py
+++ b/followers/followers/linefollower_module.py
@@ -132,8 +132,8 @@ class LineFollowerModule:
         error_mean = error_sum / len(self.control_points_)
 
         # Draw circles for other control points
-        cv.circle(self.image_debug_, self.leftT_,     radius=5, color=(0, 0, 255), thickness=-1)
-        cv.circle(self.image_debug_, self.rightT_,    radius=5, color=(0, 0, 255), thickness=-1)
+        cv.circle(self.image_debug_, self.leftT_,  radius=5, color=(0, 0, 255), thickness=-1)
+        cv.circle(self.image_debug_, self.rightT_, radius=5, color=(0, 0, 255), thickness=-1)
 
         # recognizing 90 degree turn
         is_left_in_polygon = self._is_in_polygon(contour, self.leftT_)

--- a/followers/followers/linefollower_module.py
+++ b/followers/followers/linefollower_module.py
@@ -4,7 +4,7 @@ from followers.pid import PID
 from rclpy.impl.rcutils_logger import RcutilsLogger
 from rclpy.logging import get_logger
 from enum import Enum
-from typing import Optional
+from typing import Optional, Tuple
 
 class LineFollowerModuleError(RuntimeError):
     pass
@@ -103,7 +103,7 @@ class LineFollowerModule:
     def compute_angular_velocity(self) -> Optional[float]:
         try:
             self.__process_image()
-            contour = self.__compute_max_contour()
+            contour, _ = self.__compute_max_contour()
 
         except LineFollowerModuleError as e:
             self.logger_.warning(f"Encountered error \"{e}\"."
@@ -178,7 +178,7 @@ class LineFollowerModule:
 
         raise LineFollowerModuleError('Cannot process image when input mode is not set')
 
-    def __compute_max_contour(self) -> np.ndarray:
+    def __compute_max_contour(self) -> Tuple[np.ndarray, float]:
         if self.image_binary_ is None:
             raise LineFollowerModuleError('Cannot compute max contour when the image is not set')
 
@@ -189,4 +189,4 @@ class LineFollowerModule:
             raise LineFollowerModuleError('No contour areas were found. Unable to compute the max contour')
 
         max_idx = np.argmax(areas)
-        return contours[max_idx]
+        return contours[max_idx], areas[max_idx]

--- a/followers/followers/linefollower_module.py
+++ b/followers/followers/linefollower_module.py
@@ -15,6 +15,12 @@ class LineFollowerModule:
         RAW = 1
         PROCESSED = 2
 
+    # Adjustable parameters
+    threshold_value = 127
+    # If <= 0 means disabled
+    binary_image_dilation = -1
+    binary_image_erosion = 5
+
     image_ = None
     input_mode_ = InputMode.NONE
     image_binary_ = None
@@ -24,8 +30,6 @@ class LineFollowerModule:
     control_points_ = [(220, 200)]
     leftT_ = (435, 270)
     rightT_ = (5, 270)
-
-    threshold_value = 127
 
     def __init__(
             self,
@@ -44,18 +48,25 @@ class LineFollowerModule:
         self.turn_offset_ = turn_offset
         self.logger_ = logger if logger is not None else get_logger("LineFollowerModule")
 
-    def recalculate_points(self, image: np.ndarray, turn_point_horizontal_ratio: float = 0.1,
-                           turn_point_vertical_ratio: float = 0.5) -> None:
+    def recalculate_points(self,
+                           image: np.ndarray,
+                           turn_point_horizontal_ratio: float = 0.1,
+                           turn_point_vertical_ratio: float = 0.5,
+                           control_point_vertical_ratio: float = 0.5) -> None:
         """
         Recalculate control points
 
-        :param turn_point_horizontal_ratio: How far from the side edge of image the control points
+        :param turn_point_horizontal_ratio: How far from the side edge of image the turn control points
         should be located (defined as what part of the whole image; 0.1 is 10% of width from the side)
 
-        :param turn_point_vertical_ratio: How far from the top edge of the image the control points
+        :param turn_point_vertical_ratio: How far from the top edge of the image the turn control points
         should be located (defined as what part of teh whole image; 0.6 is 60% of height from the top)
+
+        :param control_point_vertical_ratio: How far from the top edge of the image the control point
+        used for line tracking should be located (defined as what part of teh whole image; 0.6 is 60%
+        of height from the top)
         """
-        y = int(image.shape[0] * 0.5)
+        y = int(image.shape[0] * control_point_vertical_ratio)
         x = int(image.shape[1] * 0.5)
         self.control_points_ = [ (x, y) ]
 
@@ -156,8 +167,12 @@ class LineFollowerModule:
             _, thresh = cv.threshold(gray, self.threshold_value, 255, cv.THRESH_BINARY_INV)
             # _, thresh = cv.threshold(gray, 0, 255, cv.THRESH_BINARY_INV + cv.THRESH_OTSU)
 
-            kernel = np.ones((5, 5), np.uint8)
-            thresh = cv.erode(thresh, kernel, iterations=1)
+            if self.binary_image_dilation > 0:
+                kernel = np.ones((self.binary_image_dilation, self.binary_image_dilation), np.uint8)
+                thresh = cv.dilate(thresh, kernel, iterations=1)
+            if self.binary_image_erosion > 0:
+                kernel = np.ones((self.binary_image_erosion, self.binary_image_erosion), np.uint8)
+                thresh = cv.erode(thresh, kernel, iterations=1)
             self.image_binary_ = thresh
             return
 

--- a/minirys_camera/README.md
+++ b/minirys_camera/README.md
@@ -1,8 +1,13 @@
-# RYŚ CAMERA
+# minirys_camera
 The repository responsible for handling the robot's webcam
 
-## PACKAGES
-- ros2_rpi_camera: responsible for transmitting the image from the camera on ros2 topic
-- ros2_rpi_cv_camera: responsible for transmitting image in black and white theme via ros2 topic
-- ros2_rpi_rest_camera: responsible for transmitting the image from the camera via the REST protocol
-- ros2_rpi_video_recorder: responsible for recording video
+## Nodes
+- `ros2_rpi_camera`: responsible for transmitting the image from the camera on ros2 topic
+- `ros2_rpi_cv_camera`: responsible for transmitting image in black and white theme via ros2 topic
+- `ros2_rpi_rest_camera`: responsible for transmitting the image from the camera via the REST protocol
+- `ros2_rpi_video_recorder`: responsible for recording video
+- `simple_image_publisher`: responsible for transmitting the configurable image from both camera streams on ROS 2 topic
+  - Can publish both 'main' and 'lores' streams with different resolutions and different frame rates
+  - Both streams are transmitted on different topics - only one may be selected
+  - Each stream can be configured to transmit only a specified part of image (ROI)
+    - Data tha would be discarded anyway does not have to be transmitted - which improves performance

--- a/minirys_camera/config/simple_image_publisher_params.yaml
+++ b/minirys_camera/config/simple_image_publisher_params.yaml
@@ -1,0 +1,10 @@
+/**:
+  ros__parameters:
+    high_res_crop_factor_top: 0.0
+    high_res_crop_factor_bottom: 0.9
+    high_res_crop_factor_left: 0.2
+    high_res_crop_factor_right: 0.2
+    low_res_crop_factor_top: 0.7
+    low_res_crop_factor_bottom: 0.0
+    low_res_crop_factor_left: 0.25
+    low_res_crop_factor_right: 0.25

--- a/minirys_camera/config/simple_image_publisher_params.yaml
+++ b/minirys_camera/config/simple_image_publisher_params.yaml
@@ -1,9 +1,15 @@
 /**:
   ros__parameters:
+    high_res_frequency: 5.0
+    low_res_frequency: 20.0
+    exposure_value: -2.0
+    flip_image: True
+
     high_res_crop_factor_top: 0.0
     high_res_crop_factor_bottom: 0.9
     high_res_crop_factor_left: 0.2
     high_res_crop_factor_right: 0.2
+
     low_res_crop_factor_top: 0.7
     low_res_crop_factor_bottom: 0.0
     low_res_crop_factor_left: 0.25

--- a/minirys_camera/launch/simple_image_publisher.launch.py
+++ b/minirys_camera/launch/simple_image_publisher.launch.py
@@ -1,0 +1,39 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    namespace_value = os.environ.get('NAMESPACE')
+
+    config_path = os.path.join(
+        get_package_share_directory('minirys_camera'),
+        'config',
+        'simple_image_publisher_params.yaml'
+    )
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'high_res_topic',
+            default_value='internal/camera',
+            description='High resolution image topic to publish on'
+        ),
+        DeclareLaunchArgument(
+            'low_res_topic',
+            default_value='internal/camera_low_res',
+            description='Low resolution image topic to publish on'
+        ),
+
+        Node(
+            package='minirys_camera',
+            executable='simple_image_publisher',
+            namespace=namespace_value,
+            parameters=[config_path],
+            remappings=[
+                ('~/output/camera',         LaunchConfiguration('high_res_topic')),
+                ('~/output/camera_low_res', LaunchConfiguration('low_res_topic')),
+            ]
+        )
+    ])

--- a/minirys_camera/package.xml
+++ b/minirys_camera/package.xml
@@ -7,6 +7,15 @@
   <maintainer email="pawel.rawicki@gmail.com">pablo</maintainer>
   <license>MIT</license>
 
+  <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>cv_bridge</depend>
+
+  <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>picamera2</exec_depend>
+  <exec_depend>libcamera</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/minirys_camera/setup.py
+++ b/minirys_camera/setup.py
@@ -11,7 +11,8 @@ setup(
               source_path + '/ros2_rpi_cv_camera',
               source_path + '/ros2_rpi_rest_camera',
               source_path + '/ros2_rpi_video_recorder',
-              source_path + '/simple_image_publisher'],
+              source_path + '/simple_image_publisher',
+              ],
     data_files=[
         ('share/ament_index/resource_index/packages',
          ['resource/' + package_name]),
@@ -30,8 +31,8 @@ setup(
             'ros2_rpi_camera = ' + source_path + '.ros2_rpi_camera.ros2_rpi_camera:main',
             'ros2_rpi_cv_camera = ' + source_path + '.ros2_rpi_cv_camera.ros2_rpi_cv_camera:main',
             'ros2_rpi_rest_camera = ' + source_path + '.ros2_rpi_rest_camera.ros2_rpi_rest_camera:main',
-            'ros2_rpi_video_recorder = ' + source_path + '.ros2_rpi_video_recorder.ros2_rpi_video_recorder:main'
-            'simple_image_publisher = ' + source_path + '.simple_image_publisher.simple_image_publisher:main'
+            'ros2_rpi_video_recorder = ' + source_path + '.ros2_rpi_video_recorder.ros2_rpi_video_recorder:main',
+            'simple_image_publisher = ' + source_path + '.simple_image_publisher.simple_image_publisher:main',
         ],
     },
 )

--- a/minirys_camera/setup.py
+++ b/minirys_camera/setup.py
@@ -1,3 +1,4 @@
+import os
 from setuptools import setup
 from glob import glob
 
@@ -15,9 +16,10 @@ setup(
               ],
     data_files=[
         ('share/ament_index/resource_index/packages',
-         ['resource/' + package_name]),
+            ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        ('share/' + package_name, glob('launch/*launch.py')),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
+        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,

--- a/minirys_camera/setup.py
+++ b/minirys_camera/setup.py
@@ -10,7 +10,8 @@ setup(
     packages=[source_path + '/ros2_rpi_camera',
               source_path + '/ros2_rpi_cv_camera',
               source_path + '/ros2_rpi_rest_camera',
-              source_path + '/ros2_rpi_video_recorder'],
+              source_path + '/ros2_rpi_video_recorder',
+              source_path + '/simple_image_publisher'],
     data_files=[
         ('share/ament_index/resource_index/packages',
          ['resource/' + package_name]),
@@ -30,6 +31,7 @@ setup(
             'ros2_rpi_cv_camera = ' + source_path + '.ros2_rpi_cv_camera.ros2_rpi_cv_camera:main',
             'ros2_rpi_rest_camera = ' + source_path + '.ros2_rpi_rest_camera.ros2_rpi_rest_camera:main',
             'ros2_rpi_video_recorder = ' + source_path + '.ros2_rpi_video_recorder.ros2_rpi_video_recorder:main'
+            'simple_image_publisher = ' + source_path + '.simple_image_publisher.simple_image_publisher:main'
         ],
     },
 )

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -128,12 +128,14 @@ class SimpleImagePublisher(Node):
                                              self.low_res_crop_idx_left,
                                              self.low_res_crop_idx_right).shape
 
-        self.get_logger().info(f'Capturing main image of size {main_size} and publishing it cropped \
-                               to size {main_size_cropped} on topic "{self.publisher.topic_name}" \
-                                with frequency {high_res_frequency} Hz')
-        self.get_logger().info(f'Capturing lores image of size {lores_size} and publishing it cropped \
-                               to size {lores_size_cropped} on topic "{self.publisher_lores.topic_name}" \
-                                with frequency {low_res_frequency} Hz')
+        self.get_logger().info(f'Capturing main image of size {main_size}'
+                               + f' and publishing it cropped to size {main_size_cropped} on topic'
+                               + f' "{self.publisher_high_res.topic_name}"'
+                               + f' with frequency {high_res_frequency} Hz')
+        self.get_logger().info(f'Capturing lores image of size {lores_size}'
+                               + f' and publishing it cropped to size {lores_size_cropped} on topic'
+                               + f' "{self.publisher_low_res.topic_name}"'
+                               + f' with frequency {low_res_frequency} Hz')
 
     def configure_picamera(self, exposure_value: float, flip_image: bool):
         self.picam2 = Picamera2()
@@ -190,12 +192,14 @@ class SimpleImagePublisher(Node):
 
         return config['main']['size'], config['lores']['size']
 
-    def crop_image(self: np.ndarray, image, crop_idx_top: int, crop_idx_bottom: int,
-                   crop_idx_left: int, crop_idx_right: int) -> np.ndarray:
-        return image[
+        image_cropped = image[
             crop_idx_top:crop_idx_bottom,
             crop_idx_left:crop_idx_right
         ]
+        self.get_logger().debug(f'Received image shape {image.shape}')
+        self.get_logger().debug(f'Cropped image shape {image_cropped.shape}')
+        self.get_logger().debug(f'Received crop indices: crop_idx_top:={crop_idx_top}, crop_idx_bottom:={crop_idx_bottom}, crop_idx_left:={crop_idx_left}, crop_idx_right:={crop_idx_right}')
+        return image_cropped
 
     def image_callback(self):
         if PROFILE:

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -195,6 +195,12 @@ class SimpleImagePublisher(Node):
 
         return config['main']['size'], config['lores']['size']
 
+    def crop_image(self,
+                   image: np.ndarray,
+                   crop_idx_top: int,
+                   crop_idx_bottom: int,
+                   crop_idx_left: int,
+                   crop_idx_right: int) -> np.ndarray:
         image_cropped = image[
             crop_idx_top:crop_idx_bottom,
             crop_idx_left:crop_idx_right
@@ -210,8 +216,11 @@ class SimpleImagePublisher(Node):
             profiler.start(target_description="Main callback")
 
         image = self.picam2.capture_array('main')
-        image = self.crop_image(image, self.high_res_crop_idx_top, self.high_res_crop_idx_bottom,
-                                self.high_res_crop_idx_left, self.high_res_crop_idx_right)
+        image = self.crop_image(image,
+                                self.high_res_crop_idx_top,
+                                self.high_res_crop_idx_bottom,
+                                self.high_res_crop_idx_left,
+                                self.high_res_crop_idx_right)
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()
@@ -232,8 +241,11 @@ class SimpleImagePublisher(Node):
 
         yuv = self.picam2.capture_array('lores')
         image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
-        image = self.crop_image(image, self.low_res_crop_idx_top, self.low_res_crop_idx_bottom,
-                                self.low_res_crop_idx_left, self.low_res_crop_idx_right)
+        image = self.crop_image(image,
+                                self.low_res_crop_idx_top,
+                                self.low_res_crop_idx_bottom,
+                                self.low_res_crop_idx_left,
+                                self.low_res_crop_idx_right)
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -30,18 +30,21 @@ class SimpleImagePublisher(Node):
         self.declare_parameter('high_res_frequency', 5.0  )
         self.declare_parameter('low_res_frequency',  20.0 )
         self.declare_parameter('exposure_value',     -2.0 )
+        self.declare_parameter('flip_image',         True )
         self.declare_parameter('debug',              False)
         self.declare_parameter('enable_profiling',   False)
 
         high_res_frequency = self.get_parameter('high_res_frequency').get_parameter_value().double_value
         low_res_frequency  = self.get_parameter('low_res_frequency' ).get_parameter_value().double_value
         exposure_value     = self.get_parameter('exposure_value'    ).get_parameter_value().double_value
+        flip_image         = self.get_parameter('flip_image'        ).get_parameter_value().bool_value
         debug              = self.get_parameter('debug'             ).get_parameter_value().bool_value
         enable_profiling   = self.get_parameter('enable_profiling'  ).get_parameter_value().bool_value
 
         self.get_logger().info(f'Got parameter: high_res_frequency := {high_res_frequency}')
         self.get_logger().info(f'Got parameter: low_res_frequency  := {low_res_frequency}' )
         self.get_logger().info(f'Got parameter: exposure_value     := {exposure_value}'    )
+        self.get_logger().info(f'Got parameter: flip_image         := {flip_image}'        )
         self.get_logger().info(f'Got parameter: debug              := {debug}'             )
         self.get_logger().info(f'Got parameter: enable_profiling   := {enable_profiling}'  )
 
@@ -51,7 +54,7 @@ class SimpleImagePublisher(Node):
         self.publisher       = self.create_publisher(Image, 'internal/camera',         qos_profile=qos_profile_sensor_data)
         self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', qos_profile=qos_profile_sensor_data)
 
-        main_size, lores_size = self.configure_picamera(exposure_value)
+        main_size, lores_size = self.configure_picamera(exposure_value, flip_image)
 
         self.frame_id = os.path.join(self.get_namespace(), 'camera')
 
@@ -61,7 +64,7 @@ class SimpleImagePublisher(Node):
         self.get_logger().info(f'Publishing main image {main_size} on topic "{self.publisher.topic_name}" with frequency {high_res_frequency} Hz')
         self.get_logger().info(f'Publishing lores image {lores_size} on topic "{self.publisher_lores.topic_name}" with frequency {low_res_frequency} Hz')
 
-    def configure_picamera(self, exposure_value: float):
+    def configure_picamera(self, exposure_value: float, flip_image: bool):
         self.picam2 = Picamera2()
 
         # https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
@@ -79,7 +82,7 @@ class SimpleImagePublisher(Node):
         mode = get_hires_mode(self.picam2.sensor_modes, self.high_resolution)
 
         config = self.picam2.create_still_configuration(
-            transform=Transform(hflip=True, vflip=True),  # Flip because camera is upside down with LiDAR up
+            transform=Transform(hflip=flip_image, vflip=flip_image),  # Camera is upside down with LiDAR up
             buffer_count=6,  # The same as in video configuration to be on the safe side
             queue=True,
             sensor={

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -101,6 +101,8 @@ class SimpleImagePublisher(Node):
 
         main_size, lores_size = self.configure_picamera(exposure_value, flip_image)
         # Flip (width, height) -> (height, width) so that the size is consistent with OpenCV 'shape'
+        main_size = list(main_size)
+        lores_size = list(lores_size)
         main_size[0], main_size[1] = main_size[1], main_size[0]
         lores_size[0], lores_size[1] = lores_size[1], lores_size[0]
 

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -34,12 +34,12 @@ class SimpleImagePublisher(Node):
         self.declare_parameter('debug',              False)
         self.declare_parameter('enable_profiling',   False)
 
-        high_res_frequency = self.get_parameter('high_res_frequency').get_parameter_value().double_value
-        low_res_frequency  = self.get_parameter('low_res_frequency' ).get_parameter_value().double_value
-        exposure_value     = self.get_parameter('exposure_value'    ).get_parameter_value().double_value
-        flip_image         = self.get_parameter('flip_image'        ).get_parameter_value().bool_value
-        debug              = self.get_parameter('debug'             ).get_parameter_value().bool_value
-        enable_profiling   = self.get_parameter('enable_profiling'  ).get_parameter_value().bool_value
+        high_res_frequency = self.get_parameter('high_res_frequency').value
+        low_res_frequency  = self.get_parameter('low_res_frequency' ).value
+        exposure_value     = self.get_parameter('exposure_value'    ).value
+        flip_image         = self.get_parameter('flip_image'        ).value
+        debug              = self.get_parameter('debug'             ).value
+        enable_profiling   = self.get_parameter('enable_profiling'  ).value
 
         self.get_logger().info(f'Got parameter: high_res_frequency := {high_res_frequency}')
         self.get_logger().info(f'Got parameter: low_res_frequency  := {low_res_frequency}' )

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -12,6 +12,7 @@ from libcamera import Transform
 import os
 import cv2
 from cv_bridge import CvBridge
+import numpy as np
 
 # For debugging slow publishing
 PROFILE = False
@@ -101,8 +102,24 @@ class SimpleImagePublisher(Node):
         self.low_res_crop_idx_left   = int(lores_size[0] * low_res_crop_factor_left)
         self.low_res_crop_idx_right  = int(lores_size[0] * (1.0 - low_res_crop_factor_right))
 
-        self.get_logger().info(f'Publishing main image {main_size} on topic "{self.publisher.topic_name}" with frequency {high_res_frequency} Hz')
-        self.get_logger().info(f'Publishing lores image {lores_size} on topic "{self.publisher_lores.topic_name}" with frequency {low_res_frequency} Hz')
+        main_size_cropped = self.crop_image(np.ones(main_size),
+                                            self.high_res_crop_idx_top,
+                                            self.high_res_crop_idx_bottom,
+                                            self.high_res_crop_idx_left,
+                                            self.high_res_crop_idx_right).shape
+
+        lores_size_cropped = self.crop_image(np.ones(lores_size),
+                                             self.low_res_crop_idx_top,
+                                             self.low_res_crop_idx_bottom,
+                                             self.low_res_crop_idx_left,
+                                             self.low_res_crop_idx_right).shape
+
+        self.get_logger().info(f'Capturing main image of size {main_size} and publishing it cropped \
+                               to size {main_size_cropped} on topic "{self.publisher.topic_name}" \
+                                with frequency {high_res_frequency} Hz')
+        self.get_logger().info(f'Capturing lores image of size {lores_size} and publishing it cropped \
+                               to size {lores_size_cropped} on topic "{self.publisher_lores.topic_name}" \
+                                with frequency {low_res_frequency} Hz')
 
     def configure_picamera(self, exposure_value: float, flip_image: bool):
         self.picam2 = Picamera2()
@@ -159,15 +176,21 @@ class SimpleImagePublisher(Node):
 
         return config['main']['size'], config['lores']['size']
 
+    def crop_image(self: np.ndarray, image, crop_idx_top: int, crop_idx_bottom: int,
+                   crop_idx_left: int, crop_idx_right: int) -> np.ndarray:
+        return image[
+            crop_idx_top:crop_idx_bottom,
+            crop_idx_left:crop_idx_right
+        ]
+
     def image_callback(self):
         if PROFILE:
             profiler = Profiler()
             profiler.start(target_description="Main callback")
 
-        image = self.picam2.capture_array('main')[
-            self.high_res_crop_idx_top:self.high_res_crop_idx_bottom,
-            self.high_res_crop_idx_left:self.high_res_crop_idx_right
-        ]
+        image = self.picam2.capture_array('main')
+        image = self.crop_image(image, self.high_res_crop_idx_top, self.high_res_crop_idx_bottom,
+                                self.high_res_crop_idx_left, self.high_res_crop_idx_right)
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()
@@ -175,7 +198,6 @@ class SimpleImagePublisher(Node):
 
         image_msg = self.bridge.cv2_to_imgmsg(image, encoding='bgr8', header=header)
 
-        # NOTE(TauTheLepton): If there is a bottleneck on publishing consider publishing only relevant part of the image
         self.publisher.publish(image_msg)
 
         if PROFILE:
@@ -188,10 +210,9 @@ class SimpleImagePublisher(Node):
             profiler.start(target_description="Lores callback")
 
         yuv = self.picam2.capture_array('lores')
-        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)[
-            self.low_res_crop_idx_top:self.low_res_crop_idx_bottom,
-            self.low_res_crop_idx_left:self.low_res_crop_idx_right
-        ]
+        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
+        image = self.crop_image(image, self.low_res_crop_idx_top, self.low_res_crop_idx_bottom,
+                                self.low_res_crop_idx_left, self.low_res_crop_idx_right)
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -28,8 +28,8 @@ class SimpleImagePublisher(Node):
     def __init__(self):
         super().__init__('image_publisher')
 
-        self.declare_parameter('high_res_frequency', 5.0  )
-        self.declare_parameter('low_res_frequency',  20.0 )
+        self.declare_parameter('high_res_frequency', 5.0  )  # Set negative to disable publishing
+        self.declare_parameter('low_res_frequency',  20.0 )  # Set negative to disable publishing
         self.declare_parameter('exposure_value',     -2.0 )
         self.declare_parameter('flip_image',         True )
         self.declare_parameter('debug',              False)
@@ -100,14 +100,23 @@ class SimpleImagePublisher(Node):
         self.publisher_low_res  = self.create_publisher(Image, '~/output/camera_low_res', qos_profile=qos_profile_sensor_data)
 
         main_size, lores_size = self.configure_picamera(exposure_value, flip_image)
-        # Flip (width, height) -> (height, width) so that the size is consistent with OpenCV
+        # Flip (width, height) -> (height, width) so that the size is consistent with OpenCV 'shape'
         main_size[0], main_size[1] = main_size[1], main_size[0]
         lores_size[0], lores_size[1] = lores_size[1], lores_size[0]
 
         self.frame_id = os.path.join(self.get_namespace(), 'camera')
 
-        self.timer_high_res = self.create_timer((1.0 / high_res_frequency), self.image_callback_high_res)
-        self.timer_low_res  = self.create_timer((1.0 / low_res_frequency ), self.image_callback_low_res )
+        if high_res_frequency <= 0.0:
+            self.get_logger().warn('High resolution image publishing is disabled, because'
+                                   + f' high_res_frequency <= 0.0 ({high_res_frequency})')
+        else:
+            self.timer_high_res = self.create_timer((1.0 / high_res_frequency), self.image_callback_high_res)
+
+        if low_res_frequency <= 0.0:
+            self.get_logger().warn('Low resolution image publishing is disabled, because'
+                                   + f' low_res_frequency <= 0.0 ({low_res_frequency})')
+        else:
+            self.timer_low_res  = self.create_timer((1.0 / low_res_frequency), self.image_callback_low_res)
 
         self.high_res_crop_idx_top    = int(main_size[0] * high_res_crop_factor_top)
         self.high_res_crop_idx_bottom = int(main_size[0] * (1.0 - high_res_crop_factor_bottom))

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -125,7 +125,7 @@ class SimpleImagePublisher(Node):
             profiler.start(target_description="Lores callback")
 
         yuv = self.picam2.capture_array('lores')
-        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2BGR)
+        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -1,12 +1,17 @@
 import rclpy
-from picamera2 import Picamera2
-from libcamera import Transform
 from rclpy.node import Node  # Handles the creation of nodes
 from rclpy.qos import QoSProfile, qos_profile_sensor_data  # QoS configurations
+from rclpy.impl.logging_severity import LoggingSeverity
+
 from sensor_msgs.msg import Image
 from std_msgs.msg import Header
-from cv_bridge import CvBridge
+
+from picamera2 import Picamera2
+from libcamera import Transform
+
+import os
 import cv2
+from cv_bridge import CvBridge
 
 # For debugging slow publishing
 PROFILE = False
@@ -22,29 +27,39 @@ class SimpleImagePublisher(Node):
     def __init__(self):
         super().__init__('image_publisher')
 
+        self.declare_parameter('high_res_frequency', 5.0  )
+        self.declare_parameter('low_res_frequency',  20.0 )
+        self.declare_parameter('exposure_value',     -2.0 )
+        self.declare_parameter('debug',              False)
+        self.declare_parameter('enable_profiling',   False)
+
+        high_res_frequency = self.get_parameter('high_res_frequency').get_parameter_value().double_value
+        low_res_frequency  = self.get_parameter('low_res_frequency' ).get_parameter_value().double_value
+        exposure_value     = self.get_parameter('exposure_value'    ).get_parameter_value().double_value
+        debug              = self.get_parameter('debug'             ).get_parameter_value().bool_value
+        enable_profiling   = self.get_parameter('enable_profiling'  ).get_parameter_value().bool_value
+
+        self.get_logger().info(f'Got parameter: high_res_frequency := {high_res_frequency}')
+        self.get_logger().info(f'Got parameter: low_res_frequency  := {low_res_frequency}' )
+        self.get_logger().info(f'Got parameter: exposure_value     := {exposure_value}'    )
+        self.get_logger().info(f'Got parameter: debug              := {debug}'             )
+        self.get_logger().info(f'Got parameter: enable_profiling   := {enable_profiling}'  )
+
+        if debug:
+            self.get_logger().set_level(LoggingSeverity.DEBUG)
+
         self.publisher       = self.create_publisher(Image, 'internal/camera',         qos_profile=qos_profile_sensor_data)
         self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', qos_profile=qos_profile_sensor_data)
 
-        frame_interval_main, frame_interval_lores, exposure_value = self.get_parameters()
+        main_size, lores_size = self.configure_picamera(exposure_value)
 
-        self.configure_picamera(exposure_value)
+        self.frame_id = os.path.join(self.get_namespace(), 'camera')
 
-        self.frame_id = f'{self.get_namespace()}/camera'
+        self.timer       = self.create_timer((1.0 / high_res_frequency), self.image_callback      )
+        self.timer_lores = self.create_timer((1.0 / low_res_frequency ), self.image_callback_lores)
 
-        self.timer = self.create_timer(frame_interval_main, self.image_callback)
-        self.timer_lores = self.create_timer(frame_interval_lores, self.image_callback_lores)
-
-    def get_parameters(self):
-        self.declare_parameter('high_res_frequency', 5.0)
-        frame_interval_main = 1.0 / self.get_parameter('high_res_frequency').value
-
-        self.declare_parameter('low_res_frequency', 20.0)
-        frame_interval_lores = 1.0 / self.get_parameter('low_res_frequency').value
-
-        self.declare_parameter('exposure_value', -2.0)
-        exposure_value = self.get_parameter('exposure_value').value
-
-        return frame_interval_main, frame_interval_lores, exposure_value
+        self.get_logger().info(f'Publishing main image {main_size} on topic "{self.publisher.topic_name}" with frequency {high_res_frequency} Hz')
+        self.get_logger().info(f'Publishing lores image {lores_size} on topic "{self.publisher_lores.topic_name}" with frequency {low_res_frequency} Hz')
 
     def configure_picamera(self, exposure_value: float):
         self.picam2 = Picamera2()
@@ -53,7 +68,7 @@ class SimpleImagePublisher(Node):
         modes = self.picam2.sensor_modes
         sensor_modes_msg = 'Avalable sensor modes are:'
         for mode in modes: sensor_modes_msg += f'\n{mode}'
-        self.get_logger().info(sensor_modes_msg)
+        self.get_logger().debug(sensor_modes_msg)
 
         def get_hires_mode(modes, desired_resolution):
             for mode in modes:
@@ -81,14 +96,14 @@ class SimpleImagePublisher(Node):
             },
         )
 
-        self.get_logger().info('Requested configurations are:' +
-                               f"\nmain:  {config['main']}\nlores: {config['lores']}")
+        self.get_logger().debug('Requested configurations are:' +
+                                f"\nmain:  {config['main']}\nlores: {config['lores']}")
         self.picam2.align_configuration(config)
-        self.get_logger().info('Aligned configurations are:' +
-                               f"\nmain:  {config['main']}\nlores: {config['lores']}")
+        self.get_logger().debug('Aligned configurations are:' +
+                                f"\nmain:  {config['main']}\nlores: {config['lores']}")
         self.picam2.configure(config)
 
-        print(f"Camera controls:\n{self.picam2.camera_controls}")
+        self.get_logger().debug(f"Camera controls:\n{self.picam2.camera_controls}")
         self.picam2.set_controls({
             # "AeEnable": False,
             # "AwbEnable": False,
@@ -98,6 +113,8 @@ class SimpleImagePublisher(Node):
         })
 
         self.picam2.start()
+
+        return config['main']['size'], config['lores']['size']
 
     def image_callback(self):
         if PROFILE:

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -109,7 +109,7 @@ class SimpleImagePublisher(Node):
 
         # https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
         modes = self.picam2.sensor_modes
-        sensor_modes_msg = 'Avalable sensor modes are:'
+        sensor_modes_msg = 'Available sensor modes are:'
         for mode in modes: sensor_modes_msg += f'\n{mode}'
         self.get_logger().debug(sensor_modes_msg)
 

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -28,10 +28,10 @@ class SimpleImagePublisher(Node):
     def __init__(self):
         super().__init__('image_publisher')
 
-        self.declare_parameter('high_res_frequency', 5.0  )  # Set negative to disable publishing
-        self.declare_parameter('low_res_frequency',  20.0 )  # Set negative to disable publishing
-        self.declare_parameter('exposure_value',     -2.0 )
-        self.declare_parameter('flip_image',         True )
+        self.declare_parameter('high_res_frequency', 1.0  )  # Set negative to disable publishing
+        self.declare_parameter('low_res_frequency',  1.0  )  # Set negative to disable publishing
+        self.declare_parameter('exposure_value',     0.0  )
+        self.declare_parameter('flip_image',         False)  # By default camera is upside down when robot is oriented with LiDAR up
         self.declare_parameter('debug',              False)
         self.declare_parameter('enable_profiling',   False)
 

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -62,6 +62,20 @@ class SimpleImagePublisher(Node):
         low_res_crop_factor_left    = self.get_parameter('low_res_crop_factor_left'  ).value
         low_res_crop_factor_right   = self.get_parameter('low_res_crop_factor_right' ).value
 
+        def verify_crop_factor(value: float, name: str):
+            if value < 0.0 or 1.0 < value:
+                raise RuntimeError(f'Variable {name} = {value} is outside allowed bounds: [0.0; 1.0]')
+
+        verify_crop_factor(high_res_crop_factor_top,    'high_res_crop_factor_top'   )
+        verify_crop_factor(high_res_crop_factor_bottom, 'high_res_crop_factor_bottom')
+        verify_crop_factor(high_res_crop_factor_left,   'high_res_crop_factor_left'  )
+        verify_crop_factor(high_res_crop_factor_right,  'high_res_crop_factor_right' )
+
+        verify_crop_factor(low_res_crop_factor_top,    'low_res_crop_factor_top'   )
+        verify_crop_factor(low_res_crop_factor_bottom, 'low_res_crop_factor_bottom')
+        verify_crop_factor(low_res_crop_factor_left,   'low_res_crop_factor_left'  )
+        verify_crop_factor(low_res_crop_factor_right,  'low_res_crop_factor_right' )
+
         self.get_logger().info(f'Got parameter: high_res_frequency := {high_res_frequency}')
         self.get_logger().info(f'Got parameter: low_res_frequency  := {low_res_frequency}' )
         self.get_logger().info(f'Got parameter: exposure_value     := {exposure_value}'    )

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -1,6 +1,7 @@
 import rclpy
 from builtin_interfaces.msg import Time
 from picamera2 import Picamera2
+from libcamera import Transform
 from rclpy.node import Node  # Handles the creation of nodes
 from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
@@ -42,7 +43,23 @@ class SimpleImagePublisher(Node):
 
     def configure_picamera(self):
         self.picam2 = Picamera2()
-        config = self.picam2.create_preview_configuration(lores={"size": (self.width, self.height)})
+        # https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
+        config = self.picam2.create_still_configuration(
+            main={
+                'size': (2592, 1944),  # full frame
+                'size': (1296, 972),  # full frame
+                'format': 'RGB888',  # Compatible with OpenCV BGR default encoding
+            },
+            buffer_count=2,
+            queue=True,
+            transform=Transform(hflip=True, vflip=True),  # Flip because camera is upside down with LiDAR up
+            # lores={"size": (self.width, self.height)},
+        )
+        # self.picam2.preview_configuration.main.size = (1296, 972)
+        # self.picam2.preview_configuration.main.format = 'RGB888'
+        # self.picam2.preview_configuration.align()
+        # self.picam2.configure('preview')
+        self.picam2.align_configuration(config)
         self.picam2.configure(config)
         self.picam2.start()
 
@@ -54,7 +71,7 @@ class SimpleImagePublisher(Node):
         return time_msg
 
     def image_callback(self):
-        yuv = self.picam2.capture_array('lores')
+        yuv = self.picam2.capture_array('main')
 
         image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
         image_msg  =self.bridge.cv2_to_imgmsg(image, 'bgr8')

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -100,21 +100,24 @@ class SimpleImagePublisher(Node):
         self.publisher_lores = self.create_publisher(Image, '~/output/camera_low_res', qos_profile=qos_profile_sensor_data)
 
         main_size, lores_size = self.configure_picamera(exposure_value, flip_image)
+        # Flip (width, height) -> (height, width) so that the size is consistent with OpenCV
+        main_size[0], main_size[1] = main_size[1], main_size[0]
+        lores_size[0], lores_size[1] = lores_size[1], lores_size[0]
 
         self.frame_id = os.path.join(self.get_namespace(), 'camera')
 
         self.timer       = self.create_timer((1.0 / high_res_frequency), self.image_callback      )
         self.timer_lores = self.create_timer((1.0 / low_res_frequency ), self.image_callback_lores)
 
-        self.high_res_crop_idx_top    = int(main_size[1] * high_res_crop_factor_top)
-        self.high_res_crop_idx_bottom = int(main_size[1] * (1.0 - high_res_crop_factor_bottom))
-        self.high_res_crop_idx_left   = int(main_size[0] * high_res_crop_factor_left)
-        self.high_res_crop_idx_right  = int(main_size[0] * (1.0 - high_res_crop_factor_right))
+        self.high_res_crop_idx_top    = int(main_size[0] * high_res_crop_factor_top)
+        self.high_res_crop_idx_bottom = int(main_size[0] * (1.0 - high_res_crop_factor_bottom))
+        self.high_res_crop_idx_left   = int(main_size[1] * high_res_crop_factor_left)
+        self.high_res_crop_idx_right  = int(main_size[1] * (1.0 - high_res_crop_factor_right))
 
-        self.low_res_crop_idx_top    = int(lores_size[1] * low_res_crop_factor_top)
-        self.low_res_crop_idx_bottom = int(lores_size[1] * (1.0 - low_res_crop_factor_bottom))
-        self.low_res_crop_idx_left   = int(lores_size[0] * low_res_crop_factor_left)
-        self.low_res_crop_idx_right  = int(lores_size[0] * (1.0 - low_res_crop_factor_right))
+        self.low_res_crop_idx_top    = int(lores_size[0] * low_res_crop_factor_top)
+        self.low_res_crop_idx_bottom = int(lores_size[0] * (1.0 - low_res_crop_factor_bottom))
+        self.low_res_crop_idx_left   = int(lores_size[1] * low_res_crop_factor_left)
+        self.low_res_crop_idx_right  = int(lores_size[1] * (1.0 - low_res_crop_factor_right))
 
         main_size_cropped = self.crop_image(np.ones(main_size),
                                             self.high_res_crop_idx_top,

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -24,9 +24,9 @@ class SimpleImagePublisher(Node):
         self.publisher = self.create_publisher(Image, 'internal/camera', 10)
         self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', 10)
 
-        frame_interval_main, frame_interval_lores = self.get_parameters()
+        frame_interval_main, frame_interval_lores, exposure_value = self.get_parameters()
 
-        self.configure_picamera()
+        self.configure_picamera(exposure_value)
 
         self.frame_id = 0
         self.frame_id_lores = 0
@@ -38,12 +38,15 @@ class SimpleImagePublisher(Node):
         self.declare_parameter('high_res_frequency', 5.0)
         frame_interval_main = 1.0 / self.get_parameter('high_res_frequency').value
 
-        self.declare_parameter('low_res_frequency', 10.0)
+        self.declare_parameter('low_res_frequency', 20.0)
         frame_interval_lores = 1.0 / self.get_parameter('low_res_frequency').value
 
-        return frame_interval_main, frame_interval_lores
+        self.declare_parameter('exposure_value', -2.0)
+        exposure_value = self.get_parameter('exposure_value').value
 
-    def configure_picamera(self):
+        return frame_interval_main, frame_interval_lores, exposure_value
+
+    def configure_picamera(self, exposure_value: float):
         self.picam2 = Picamera2()
 
         # https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
@@ -74,7 +77,7 @@ class SimpleImagePublisher(Node):
             },
             lores={
                 'size': self.low_resolution,
-                # 'format': 'RGB888',  # Format is mandatory to be YUV420 on Pi 4
+                # 'format': 'RGB888',  # Format is mandatory to be YUV420 on Pi 4 in lores stream
             },
         )
 
@@ -87,11 +90,11 @@ class SimpleImagePublisher(Node):
 
         print(f"Camera controls:\n{self.picam2.camera_controls}")
         self.picam2.set_controls({
-            # "AeEnable": False,         # Disable auto-exposure
-            # "AwbEnable": False,        # Optionally disable auto white balance
-            # "ExposureTime": 1000,        # Use a short exposure time (near the minimum)
-            "ExposureValue": -2.0,        # Use a short exposure time (near the minimum)
-            # "AnalogueGain": 1.0,       # Use the minimal analogue gain
+            # "AeEnable": False,
+            # "AwbEnable": False,
+            # "ExposureTime": 1000,
+            "ExposureValue": exposure_value,
+            # "AnalogueGain": 1.0,
         })
 
         self.picam2.start()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -24,22 +24,24 @@ class SimpleImagePublisher(Node):
         self.publisher = self.create_publisher(Image, 'internal/camera', 10)
         self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', 10)
 
-        self.declareParameters()
+        frame_interval_main, frame_interval_lores = self.get_parameters()
 
         self.configure_picamera()
 
         self.frame_id = 0
         self.frame_id_lores = 0
 
-        self.timer = self.create_timer(self.frame_interval_main, self.image_callback_lores)
-        self.timer_lores = self.create_timer(self.frame_interval_lores, self.image_callback)
+        self.timer = self.create_timer(frame_interval_main, self.image_callback)
+        self.timer_lores = self.create_timer(frame_interval_lores, self.image_callback_lores)
 
-    def declareParameters(self):
-        self.declare_parameter('high_res_frequency', 20.0)
-        self.frame_interval_main = 1.0 / self.get_parameter('high_res_frequency').value
+    def get_parameters(self):
+        self.declare_parameter('high_res_frequency', 5.0)
+        frame_interval_main = 1.0 / self.get_parameter('high_res_frequency').value
 
-        self.declare_parameter('low_res_frequency', 5.0)
-        self.frame_interval_lores = 1.0 / self.get_parameter('low_res_frequency').value
+        self.declare_parameter('low_res_frequency', 10.0)
+        frame_interval_lores = 1.0 / self.get_parameter('low_res_frequency').value
+
+        return frame_interval_main, frame_interval_lores
 
     def configure_picamera(self):
         self.picam2 = Picamera2()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -96,8 +96,8 @@ class SimpleImagePublisher(Node):
         if debug:
             self.get_logger().set_level(LoggingSeverity.DEBUG)
 
-        self.publisher       = self.create_publisher(Image, '~/output/camera',         qos_profile=qos_profile_sensor_data)
-        self.publisher_lores = self.create_publisher(Image, '~/output/camera_low_res', qos_profile=qos_profile_sensor_data)
+        self.publisher_high_res = self.create_publisher(Image, '~/output/camera',         qos_profile=qos_profile_sensor_data)
+        self.publisher_low_res  = self.create_publisher(Image, '~/output/camera_low_res', qos_profile=qos_profile_sensor_data)
 
         main_size, lores_size = self.configure_picamera(exposure_value, flip_image)
         # Flip (width, height) -> (height, width) so that the size is consistent with OpenCV
@@ -106,8 +106,8 @@ class SimpleImagePublisher(Node):
 
         self.frame_id = os.path.join(self.get_namespace(), 'camera')
 
-        self.timer       = self.create_timer((1.0 / high_res_frequency), self.image_callback      )
-        self.timer_lores = self.create_timer((1.0 / low_res_frequency ), self.image_callback_lores)
+        self.timer_high_res = self.create_timer((1.0 / high_res_frequency), self.image_callback_high_res)
+        self.timer_low_res  = self.create_timer((1.0 / low_res_frequency ), self.image_callback_low_res )
 
         self.high_res_crop_idx_top    = int(main_size[0] * high_res_crop_factor_top)
         self.high_res_crop_idx_bottom = int(main_size[0] * (1.0 - high_res_crop_factor_bottom))
@@ -210,7 +210,7 @@ class SimpleImagePublisher(Node):
         self.get_logger().debug(f'Received crop indices: crop_idx_top:={crop_idx_top}, crop_idx_bottom:={crop_idx_bottom}, crop_idx_left:={crop_idx_left}, crop_idx_right:={crop_idx_right}')
         return image_cropped
 
-    def image_callback(self):
+    def image_callback_high_res(self):
         if PROFILE:
             profiler = Profiler()
             profiler.start(target_description="Main callback")
@@ -228,13 +228,13 @@ class SimpleImagePublisher(Node):
 
         image_msg = self.bridge.cv2_to_imgmsg(image, encoding='bgr8', header=header)
 
-        self.publisher.publish(image_msg)
+        self.publisher_high_res.publish(image_msg)
 
         if PROFILE:
             profiler.stop()
             profiler.print()
 
-    def image_callback_lores(self):
+    def image_callback_low_res(self):
         if PROFILE:
             profiler = Profiler()
             profiler.start(target_description="Lores callback")
@@ -253,7 +253,7 @@ class SimpleImagePublisher(Node):
 
         image_msg = self.bridge.cv2_to_imgmsg(image, encoding='bgr8', header=header)
 
-        self.publisher_lores.publish(image_msg)
+        self.publisher_low_res.publish(image_msg)
 
         if PROFILE:
             profiler.stop()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -1,9 +1,10 @@
 import rclpy
-from builtin_interfaces.msg import Time
 from picamera2 import Picamera2
 from libcamera import Transform
 from rclpy.node import Node  # Handles the creation of nodes
+from rclpy.qos import QoSProfile, qos_profile_sensor_data  # QoS configurations
 from sensor_msgs.msg import Image
+from std_msgs.msg import Header
 from cv_bridge import CvBridge
 import cv2
 
@@ -21,15 +22,14 @@ class SimpleImagePublisher(Node):
     def __init__(self):
         super().__init__('image_publisher')
 
-        self.publisher = self.create_publisher(Image, 'internal/camera', 10)
-        self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', 10)
+        self.publisher       = self.create_publisher(Image, 'internal/camera',         qos_profile=qos_profile_sensor_data)
+        self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', qos_profile=qos_profile_sensor_data)
 
         frame_interval_main, frame_interval_lores, exposure_value = self.get_parameters()
 
         self.configure_picamera(exposure_value)
 
-        self.frame_id = 0
-        self.frame_id_lores = 0
+        self.frame_id = f'{self.get_namespace()}/camera'
 
         self.timer = self.create_timer(frame_interval_main, self.image_callback)
         self.timer_lores = self.create_timer(frame_interval_lores, self.image_callback_lores)
@@ -99,23 +99,19 @@ class SimpleImagePublisher(Node):
 
         self.picam2.start()
 
-    def get_time_msg(self):
-        time_msg = Time()
-        msg_time = self.get_clock().now().seconds_nanoseconds()
-        time_msg.sec = int(msg_time[0])
-        time_msg.nanosec = int(msg_time[1])
-        return time_msg
-
     def image_callback(self):
         if PROFILE:
             profiler = Profiler()
             profiler.start(target_description="Main callback")
 
         image = self.picam2.capture_array('main')
-        image_msg = self.bridge.cv2_to_imgmsg(image)
 
-        self.frame_id += 1
-        image_msg.header.frame_id = str(self.frame_id)
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = self.frame_id
+
+        image_msg = self.bridge.cv2_to_imgmsg(image, encoding='bgr8', header=header)
+
         self.publisher.publish(image_msg)
 
         if PROFILE:
@@ -128,11 +124,14 @@ class SimpleImagePublisher(Node):
             profiler.start(target_description="Lores callback")
 
         yuv = self.picam2.capture_array('lores')
-        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
-        image_msg = self.bridge.cv2_to_imgmsg(image)
+        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2BGR)
 
-        self.frame_id_lores += 1
-        image_msg.header.frame_id = str(self.frame_id_lores)
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = self.frame_id
+
+        image_msg = self.bridge.cv2_to_imgmsg(image, encoding='bgr8', header=header)
+
         self.publisher_lores.publish(image_msg)
 
         if PROFILE:

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -34,6 +34,16 @@ class SimpleImagePublisher(Node):
         self.declare_parameter('debug',              False)
         self.declare_parameter('enable_profiling',   False)
 
+        self.declare_parameter('high_res_crop_factor_top',    0.0)
+        self.declare_parameter('high_res_crop_factor_bottom', 0.0)
+        self.declare_parameter('high_res_crop_factor_left',   0.0)
+        self.declare_parameter('high_res_crop_factor_right',  0.0)
+
+        self.declare_parameter('low_res_crop_factor_top',    0.0)
+        self.declare_parameter('low_res_crop_factor_bottom', 0.0)
+        self.declare_parameter('low_res_crop_factor_left',   0.0)
+        self.declare_parameter('low_res_crop_factor_right',  0.0)
+
         high_res_frequency = self.get_parameter('high_res_frequency').value
         low_res_frequency  = self.get_parameter('low_res_frequency' ).value
         exposure_value     = self.get_parameter('exposure_value'    ).value
@@ -41,12 +51,32 @@ class SimpleImagePublisher(Node):
         debug              = self.get_parameter('debug'             ).value
         enable_profiling   = self.get_parameter('enable_profiling'  ).value
 
+        high_res_crop_factor_top    = self.get_parameter('high_res_crop_factor_top'   ).value
+        high_res_crop_factor_bottom = self.get_parameter('high_res_crop_factor_bottom').value
+        high_res_crop_factor_left   = self.get_parameter('high_res_crop_factor_left'  ).value
+        high_res_crop_factor_right  = self.get_parameter('high_res_crop_factor_right' ).value
+
+        low_res_crop_factor_top     = self.get_parameter('low_res_crop_factor_top'   ).value
+        low_res_crop_factor_bottom  = self.get_parameter('low_res_crop_factor_bottom').value
+        low_res_crop_factor_left    = self.get_parameter('low_res_crop_factor_left'  ).value
+        low_res_crop_factor_right   = self.get_parameter('low_res_crop_factor_right' ).value
+
         self.get_logger().info(f'Got parameter: high_res_frequency := {high_res_frequency}')
         self.get_logger().info(f'Got parameter: low_res_frequency  := {low_res_frequency}' )
         self.get_logger().info(f'Got parameter: exposure_value     := {exposure_value}'    )
         self.get_logger().info(f'Got parameter: flip_image         := {flip_image}'        )
         self.get_logger().info(f'Got parameter: debug              := {debug}'             )
         self.get_logger().info(f'Got parameter: enable_profiling   := {enable_profiling}'  )
+
+        self.get_logger().info(f'Got parameter: high_res_crop_factor_top    := {high_res_crop_factor_top}'   )
+        self.get_logger().info(f'Got parameter: high_res_crop_factor_bottom := {high_res_crop_factor_bottom}')
+        self.get_logger().info(f'Got parameter: high_res_crop_factor_left   := {high_res_crop_factor_left}'  )
+        self.get_logger().info(f'Got parameter: high_res_crop_factor_right  := {high_res_crop_factor_right}' )
+
+        self.get_logger().info(f'Got parameter: low_res_crop_factor_top     := {low_res_crop_factor_top}'   )
+        self.get_logger().info(f'Got parameter: low_res_crop_factor_bottom  := {low_res_crop_factor_bottom}')
+        self.get_logger().info(f'Got parameter: low_res_crop_factor_left    := {low_res_crop_factor_left}'  )
+        self.get_logger().info(f'Got parameter: low_res_crop_factor_right   := {low_res_crop_factor_right}' )
 
         if debug:
             self.get_logger().set_level(LoggingSeverity.DEBUG)
@@ -60,6 +90,16 @@ class SimpleImagePublisher(Node):
 
         self.timer       = self.create_timer((1.0 / high_res_frequency), self.image_callback      )
         self.timer_lores = self.create_timer((1.0 / low_res_frequency ), self.image_callback_lores)
+
+        self.high_res_crop_idx_top    = int(main_size[1] * high_res_crop_factor_top)
+        self.high_res_crop_idx_bottom = int(main_size[1] * (1.0 - high_res_crop_factor_bottom))
+        self.high_res_crop_idx_left   = int(main_size[0] * high_res_crop_factor_left)
+        self.high_res_crop_idx_right  = int(main_size[0] * (1.0 - high_res_crop_factor_right))
+
+        self.low_res_crop_idx_top    = int(lores_size[1] * low_res_crop_factor_top)
+        self.low_res_crop_idx_bottom = int(lores_size[1] * (1.0 - low_res_crop_factor_bottom))
+        self.low_res_crop_idx_left   = int(lores_size[0] * low_res_crop_factor_left)
+        self.low_res_crop_idx_right  = int(lores_size[0] * (1.0 - low_res_crop_factor_right))
 
         self.get_logger().info(f'Publishing main image {main_size} on topic "{self.publisher.topic_name}" with frequency {high_res_frequency} Hz')
         self.get_logger().info(f'Publishing lores image {lores_size} on topic "{self.publisher_lores.topic_name}" with frequency {low_res_frequency} Hz')
@@ -124,7 +164,10 @@ class SimpleImagePublisher(Node):
             profiler = Profiler()
             profiler.start(target_description="Main callback")
 
-        image = self.picam2.capture_array('main')
+        image = self.picam2.capture_array('main')[
+            self.high_res_crop_idx_top:self.high_res_crop_idx_bottom,
+            self.high_res_crop_idx_left:self.high_res_crop_idx_right
+        ]
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()
@@ -145,7 +188,10 @@ class SimpleImagePublisher(Node):
             profiler.start(target_description="Lores callback")
 
         yuv = self.picam2.capture_array('lores')
-        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
+        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)[
+            self.low_res_crop_idx_top:self.low_res_crop_idx_bottom,
+            self.low_res_crop_idx_left:self.low_res_crop_idx_right
+        ]
 
         header = Header()
         header.stamp = self.get_clock().now().to_msg()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -7,60 +7,82 @@ from sensor_msgs.msg import Image
 from cv_bridge import CvBridge
 import cv2
 
-ENCODING = "rgba8"  # http://docs.ros.org/en/jade/api/sensor_msgs/html/image__encodings_8h_source.html
-
-DEFAULT_WIDTH = 640
-DEFAULT_HEIGHT = 480
-
-DEFAULT_FRAME_INTERVAL = 0.1
-
+# For debugging slow publishing
+PROFILE = False
+if PROFILE: from pyinstrument import Profiler
 
 class SimpleImagePublisher(Node):
     bridge = CvBridge()
+
+    low_resolution = (640, 480)  # almost full frame
+    high_resolution = (1296, 972)  # full frame
+    very_high_resolution = (2592, 1944)  # full frame
 
     def __init__(self):
         super().__init__('image_publisher')
 
         self.publisher = self.create_publisher(Image, 'internal/camera', 10)
+        self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', 10)
 
         self.declareParameters()
 
         self.configure_picamera()
 
         self.frame_id = 0
+        self.frame_id_lores = 0
 
-        self.create_timer(self.frame_interval, self.image_callback)
+        self.timer = self.create_timer(self.frame_interval_main, self.image_callback_lores)
+        self.timer_lores = self.create_timer(self.frame_interval_lores, self.image_callback)
 
     def declareParameters(self):
-        self.declare_parameter('width', DEFAULT_WIDTH)
-        self.width = self.get_parameter('width').value
+        self.declare_parameter('high_res_frequency', 20.0)
+        self.frame_interval_main = 1.0 / self.get_parameter('high_res_frequency').value
 
-        self.declare_parameter('height', DEFAULT_HEIGHT)
-        self.height = self.get_parameter('height').value
-
-        self.declare_parameter('frame_interval', DEFAULT_FRAME_INTERVAL)
-        self.frame_interval = self.get_parameter('frame_interval').value
+        self.declare_parameter('low_res_frequency', 5.0)
+        self.frame_interval_lores = 1.0 / self.get_parameter('low_res_frequency').value
 
     def configure_picamera(self):
         self.picam2 = Picamera2()
+
         # https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf
+        modes = self.picam2.sensor_modes
+        sensor_modes_msg = 'Avalable sensor modes are:'
+        for mode in modes: sensor_modes_msg += f'\n{mode}'
+        self.get_logger().info(sensor_modes_msg)
+
+        def get_hires_mode(modes, desired_resolution):
+            for mode in modes:
+                if mode['size'] == desired_resolution:
+                    return mode
+            raise RuntimeError('Could not obtain a high resolution sensor mode')
+
+        mode = get_hires_mode(self.picam2.sensor_modes, self.high_resolution)
+
         config = self.picam2.create_still_configuration(
+            transform=Transform(hflip=True, vflip=True),  # Flip because camera is upside down with LiDAR up
+            buffer_count=6,  # The same as in video configuration to be on the safe side
+            queue=True,
+            sensor={
+                'output_size': mode['size'],
+                'bit_depth': mode['bit_depth'],
+            },
             main={
-                'size': (2592, 1944),  # full frame
-                'size': (1296, 972),  # full frame
+                'size': self.high_resolution,
                 'format': 'RGB888',  # Compatible with OpenCV BGR default encoding
             },
-            buffer_count=2,
-            queue=True,
-            transform=Transform(hflip=True, vflip=True),  # Flip because camera is upside down with LiDAR up
-            # lores={"size": (self.width, self.height)},
+            lores={
+                'size': self.low_resolution,
+                # 'format': 'RGB888',  # Format is mandatory to be YUV420 on Pi 4
+            },
         )
-        # self.picam2.preview_configuration.main.size = (1296, 972)
-        # self.picam2.preview_configuration.main.format = 'RGB888'
-        # self.picam2.preview_configuration.align()
-        # self.picam2.configure('preview')
+
+        self.get_logger().info('Requested configurations are:' +
+                               f"\nmain:  {config['main']}\nlores: {config['lores']}")
         self.picam2.align_configuration(config)
+        self.get_logger().info('Aligned configurations are:' +
+                               f"\nmain:  {config['main']}\nlores: {config['lores']}")
         self.picam2.configure(config)
+
         self.picam2.start()
 
     def get_time_msg(self):
@@ -71,14 +93,37 @@ class SimpleImagePublisher(Node):
         return time_msg
 
     def image_callback(self):
-        yuv = self.picam2.capture_array('main')
+        if PROFILE:
+            profiler = Profiler()
+            profiler.start(target_description="Main callback")
 
-        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
-        image_msg  =self.bridge.cv2_to_imgmsg(image, 'bgr8')
+        image = self.picam2.capture_array('main')
+        image_msg = self.bridge.cv2_to_imgmsg(image)
 
         self.frame_id += 1
         image_msg.header.frame_id = str(self.frame_id)
         self.publisher.publish(image_msg)
+
+        if PROFILE:
+            profiler.stop()
+            profiler.print()
+
+    def image_callback_lores(self):
+        if PROFILE:
+            profiler = Profiler()
+            profiler.start(target_description="Lores callback")
+
+        yuv = self.picam2.capture_array('lores')
+        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
+        image_msg = self.bridge.cv2_to_imgmsg(image)
+
+        self.frame_id_lores += 1
+        image_msg.header.frame_id = str(self.frame_id_lores)
+        self.publisher_lores.publish(image_msg)
+
+        if PROFILE:
+            profiler.stop()
+            profiler.print()
 
 def main(args=None):
     rclpy.init(args=args)

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -1,0 +1,73 @@
+import rclpy
+from builtin_interfaces.msg import Time
+from picamera2 import Picamera2
+from rclpy.node import Node  # Handles the creation of nodes
+from sensor_msgs.msg import Image
+from cv_bridge import CvBridge
+import cv2
+
+ENCODING = "rgba8"  # http://docs.ros.org/en/jade/api/sensor_msgs/html/image__encodings_8h_source.html
+
+DEFAULT_WIDTH = 640
+DEFAULT_HEIGHT = 480
+
+DEFAULT_FRAME_INTERVAL = 0.1
+
+
+class SimpleImagePublisher(Node):
+    bridge = CvBridge()
+
+    def __init__(self):
+        super().__init__('image_publisher')
+
+        self.publisher = self.create_publisher(Image, 'internal/camera', 10)
+
+        self.declareParameters()
+
+        self.configure_picamera()
+
+        self.frame_id = 0
+
+        self.create_timer(self.frame_interval, self.image_callback)
+
+    def declareParameters(self):
+        self.declare_parameter('width', DEFAULT_WIDTH)
+        self.width = self.get_parameter('width').value
+
+        self.declare_parameter('height', DEFAULT_HEIGHT)
+        self.height = self.get_parameter('height').value
+
+        self.declare_parameter('frame_interval', DEFAULT_FRAME_INTERVAL)
+        self.frame_interval = self.get_parameter('frame_interval').value
+
+    def configure_picamera(self):
+        self.picam2 = Picamera2()
+        config = self.picam2.create_preview_configuration(lores={"size": (self.width, self.height)})
+        self.picam2.configure(config)
+        self.picam2.start()
+
+    def get_time_msg(self):
+        time_msg = Time()
+        msg_time = self.get_clock().now().seconds_nanoseconds()
+        time_msg.sec = int(msg_time[0])
+        time_msg.nanosec = int(msg_time[1])
+        return time_msg
+
+    def image_callback(self):
+        yuv = self.picam2.capture_array('lores')
+
+        image = cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
+        image_msg  =self.bridge.cv2_to_imgmsg(image, 'bgr8')
+
+        self.frame_id += 1
+        image_msg.header.frame_id = str(self.frame_id)
+        self.publisher.publish(image_msg)
+
+def main(args=None):
+    rclpy.init(args=args)
+    simple_image_publisher = SimpleImagePublisher()
+    rclpy.spin(simple_image_publisher)
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -90,7 +90,7 @@ class SimpleImagePublisher(Node):
             # "AeEnable": False,         # Disable auto-exposure
             # "AwbEnable": False,        # Optionally disable auto white balance
             # "ExposureTime": 1000,        # Use a short exposure time (near the minimum)
-            "ExposureValue": -2.5,        # Use a short exposure time (near the minimum)
+            "ExposureValue": -2.0,        # Use a short exposure time (near the minimum)
             # "AnalogueGain": 1.0,       # Use the minimal analogue gain
         })
 

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -96,8 +96,8 @@ class SimpleImagePublisher(Node):
         if debug:
             self.get_logger().set_level(LoggingSeverity.DEBUG)
 
-        self.publisher       = self.create_publisher(Image, 'internal/camera',         qos_profile=qos_profile_sensor_data)
-        self.publisher_lores = self.create_publisher(Image, 'internal/camera_low_res', qos_profile=qos_profile_sensor_data)
+        self.publisher       = self.create_publisher(Image, '~/output/camera',         qos_profile=qos_profile_sensor_data)
+        self.publisher_lores = self.create_publisher(Image, '~/output/camera_low_res', qos_profile=qos_profile_sensor_data)
 
         main_size, lores_size = self.configure_picamera(exposure_value, flip_image)
 

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -85,6 +85,15 @@ class SimpleImagePublisher(Node):
                                f"\nmain:  {config['main']}\nlores: {config['lores']}")
         self.picam2.configure(config)
 
+        print(f"Camera controls:\n{self.picam2.camera_controls}")
+        self.picam2.set_controls({
+            # "AeEnable": False,         # Disable auto-exposure
+            # "AwbEnable": False,        # Optionally disable auto white balance
+            # "ExposureTime": 1000,        # Use a short exposure time (near the minimum)
+            "ExposureValue": -2.5,        # Use a short exposure time (near the minimum)
+            # "AnalogueGain": 1.0,       # Use the minimal analogue gain
+        })
+
         self.picam2.start()
 
     def get_time_msg(self):

--- a/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
+++ b/minirys_camera/src/simple_image_publisher/simple_image_publisher.py
@@ -112,6 +112,7 @@ class SimpleImagePublisher(Node):
 
         image_msg = self.bridge.cv2_to_imgmsg(image, encoding='bgr8', header=header)
 
+        # NOTE(TauTheLepton): If there is a bottleneck on publishing consider publishing only relevant part of the image
         self.publisher.publish(image_msg)
 
         if PROFILE:

--- a/minirys_ros2/src/nodes/CommunicationNode.cpp
+++ b/minirys_ros2/src/nodes/CommunicationNode.cpp
@@ -13,6 +13,9 @@ CommunicationNode::CommunicationNode(rclcpp::NodeOptions options):
 	Node("communication_cs", options) {
 	RCLCPP_INFO(this->get_logger(), "Initializing data relays");
 
+	declare_parameter<bool>("publish_namespaces", false);
+	const bool publish_namespaces = get_parameter("publish_namespaces").as_bool();
+
 	// Battery
 	this->batteryStatusSubscription = this->create_subscription<minirys_msgs::msg::BatteryStatus>(
 		"internal/battery_status",
@@ -57,7 +60,9 @@ CommunicationNode::CommunicationNode(rclcpp::NodeOptions options):
 
 	this->robotsNamespacesPublisher = this->create_publisher<minirys_msgs::msg::RobotsNamespaces>("robots_namespaces", 10);
 
-	timer_ = this->create_wall_timer(1s, std::bind(&CommunicationNode::publishNamespaces, this));
+	if (publish_namespaces) {
+		timer_ = this->create_wall_timer(1s, std::bind(&CommunicationNode::publishNamespaces, this));
+	}
 
 
 	RCLCPP_INFO(this->get_logger(), "Data relays initialized");


### PR DESCRIPTION
# Description
This PR changes 3 things
- Adds `simple_image_publisher` node
  - This node can publish images on two topics using two Picamera2 streams
    - "main" - high resolution and better image processing
    - "lores" - low resolution and limited image processing
  - The published images can be cropped to include only specific ROI (region of interest)
    - This improves performance
  - The two streams can be published with different frequencies or even one of them can be disabled
    - This can further enhance performance when you need low resolution image often (e.g. 30Hz), but high resolution not (e.g. 2Hz)
- Slightly improves `LineFollowerModule`
  - Adds some configurability and disables member function name mangling so that class inheritance is possible
    - This makes the member functions prefixed with `_` somewhat "protected" rather than "private"
- Disables robot namespaces publishing by default
  - This can be enabled with parameter
  - It is turned off because it requires a lot of resources and is rarely necessary